### PR TITLE
Use localhost as default DB hostname

### DIFF
--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -125,7 +125,7 @@ final class PerfOptions {
 
   public bool $notBenchmarking = false;
 
-  public string $dbHost = '127.0.0.1'; //The hostname/IP of server which hosts the database.
+  public string $dbHost = 'localhost'; //The hostname/IP of server which hosts the database.
   public int $memcachedPort; //The hostname/IP of server which hosts memcached.
   public int $memcachedThreads; // Number of memcached threads
 


### PR DESCRIPTION
For systems that only support IPv6, we want to use localhost
instead of 127.0.0.1, so it can resolve to whatever loopback
address is available, instead of assuming IPv4.