### PR TITLE
Improve robustness and safety

### DIFF
--- a/base/HHVMDaemon.php
+++ b/base/HHVMDaemon.php
@@ -17,6 +17,7 @@ final class HHVMDaemon extends PHPEngine {
     parent::__construct((string) $options->hhvm);
 
     $this->serverType = $options->proxygen ? 'proxygen' : 'fastcgi';
+    $runAsRoot = $options->runAsRoot ? '1' : '0';
 
     $output = [];
     $check_command = implode(
@@ -25,6 +26,8 @@ final class HHVMDaemon extends PHPEngine {
          $options->hhvm,
          '-v',
          'Eval.Jit=1',
+         '-v',
+         'Server.AllowRunAsRoot='.$runAsRoot,
          __DIR__.'/hhvm_config_check.php',
        })->map($x ==> escapeshellarg($x)),
     );
@@ -103,6 +106,10 @@ final class HHVMDaemon extends PHPEngine {
       '-c',
       OSS_PERFORMANCE_ROOT.'/conf/php.ini',
     };
+
+    if ($this->options->runAsRoot) {
+      $args->addAll(Vector {'-v', 'Server.AllowRunAsRoot=1'});
+    }
     if ($this->options->jit) {
       $args->addAll(Vector {'-v', 'Eval.Jit=1'});
     } else {

--- a/base/MemcachedDaemon.php
+++ b/base/MemcachedDaemon.php
@@ -59,17 +59,18 @@ final class MemcachedDaemon extends Process {
     if ($this->options->cpuBind) {
       $this->cpuRange = $this->options->helperProcessors;
     }
+    $processUser = posix_getpwuid(posix_geteuid());
     return Vector {
       '-m',
       (string) $this->maxMemory,
-      '-l',
-      '127.0.0.1',
       '-t',
       (string) $this->getNumThreads(),
       '-p',
       (string) $this->options->memcachedPort,
       '-P', # pid file
-      $this->getPidFilePath()
+      $this->getPidFilePath(),
+      '-u',
+      $processUser['name'],
     };
   }
 }

--- a/base/PerfOptions.php
+++ b/base/PerfOptions.php
@@ -55,6 +55,7 @@ final class PerfOptions {
   public bool $dumpIsCompressed = true;
   public bool $traceSubProcess = false;
   public bool $noTimeLimit = false;
+  public bool $runAsRoot = false;
 
   // Pause once benchmarking is complete to allow for manual inspection of the
   // HHVM or PHP process.
@@ -174,6 +175,7 @@ final class PerfOptions {
       'php-extra-arguments:',
       'php-fcgi-children:',
       'no-time-limit',
+      'run-as-root',
       'fetch-resources',
       'skip-sanity-check',
       'skip-warmup',
@@ -284,6 +286,7 @@ final class PerfOptions {
     $this->skipVersionChecks = $this->getBool('skip-version-checks');
     $this->skipDatabaseInstall = $this->getBool('skip-database-install');
     $this->noTimeLimit = $this->getBool('no-time-limit');
+    $this->runAsRoot = $this->getBool('run-as-root');
     $this->waitAtEnd = $this->getBool('wait-at-end');
     $this->proxygen = !$this->getBool('no-proxygen');
     $this->statCache = $this->getBool('stat-cache');

--- a/base/SystemChecks.php
+++ b/base/SystemChecks.php
@@ -10,15 +10,26 @@
 
 class SystemChecks {
   public static function CheckAll(PerfOptions $options): void {
-    self::CheckNotRoot();
+    self::CheckNotRoot($options);
     self::CheckPortAvailability($options);
     self::CheckCPUFreq();
     self::CheckTCPTimeWaitReuse();
     self::CheckForAuditd($options);
   }
 
-  private static function CheckNotRoot(): void {
-    invariant(getmyuid() !== 0, 'Run this script as a regular user.');
+  private static function CheckNotRoot(PerfOptions $options): void {
+    if ($options->runAsRoot) {
+      fprintf(
+          STDERR,
+          "WARNING: Running as root. This is dangerous.\n"
+        );
+    } else {
+      invariant(
+        getmyuid() !== 0,
+        'Run this script as a regular user. Alternatively, '.
+        'pass the --run-as-root --i-am-not-benchmarking to continue anway.'
+      );
+    }
   }
 
   private static function CheckForAuditd(PerfOptions $options): void {

--- a/conf/nginx/nginx.conf.in
+++ b/conf/nginx/nginx.conf.in
@@ -33,6 +33,8 @@ http {
 
   #gzip  on;
 
+  __NGINX_RESOLVER__
+
   server {
     listen [::]:__HTTP_PORT__ default_server;
     listen __HTTP_PORT__ default_server;


### PR DESCRIPTION
Instead of assuming IPv4 explicitly, we try to use default to localhost, and update Nginx conf accordingly.

Adds `--run-as-root` option which requires `--i-am-not-benchmarking` as well 